### PR TITLE
Added handling POSIXct and POSIXT datetypes to prep_match_datatypes

### DIFF
--- a/R/prep_match_datatypes.R
+++ b/R/prep_match_datatypes.R
@@ -47,10 +47,13 @@ prep_match_datatypes <- function(ref_dataframe, target_dataframe) {
         target_dataframe <- target_dataframe |>
           dplyr::mutate(!!col := as.logical(!!rlang::sym(col)))
       } else if (col_type == "Date") {
-        
         target_dataframe <- target_dataframe |>
           dplyr::mutate(!!col := as.Date(!!rlang::sym(col)
-                                         # format = "Y-%m-%d"
+          ))
+      } else if (col_type == 'c("POSIXct", "POSIXt")') {
+        target_dataframe <- target_dataframe |>
+          dplyr::mutate(!!col == as.POSIXct(!!rlang::sym(col),
+                                            format = "YYYY-MM-DD"
           ))
       }
     }


### PR DESCRIPTION
Noticed my code was breaking because of this line of code that was removed.

else if (col_type == 'c("POSIXct", "POSIXt")') {
        target_dataframe <- target_dataframe |>
          dplyr::mutate(!!col == as.POSIXct(!!rlang::sym(col),
                                            format = "YYYY-MM-DD"
          ))
          
Just added it back. The AFP database dates evaluates to 'c("POSIXct", "POSIXt")' instead and not Date, so in so doing it was not able to match the datatypes.